### PR TITLE
Reflect exit code of child processes

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,6 @@
+build:
+	meson setup build
+	ninja -C build
+
+clean:
+	rm -rf build

--- a/reaper.cpp
+++ b/reaper.cpp
@@ -52,14 +52,28 @@ int main( int argc, char **argv )
 	}
 
 	pid_t wait_ret;
+	int child_status;
+	bool child_failed = false;
 	while( true )
 	{
-		wait_ret = wait( NULL );
+		wait_ret = wait( &child_status );
+
+		if ( child_status != 0 )
+		{
+			child_failed = true;
+		}
 
 		if ( wait_ret == -1 && errno == ECHILD )
 		{
 			// No more children.
 			break;
 		}
+	}
+
+	if ( child_failed )
+	{
+		exit ( 1 );
+	} else {
+		exit ( 0 );
 	}
 }


### PR DESCRIPTION
If any child process reports a non-zero exit code, reaper returns a non-zero exit code, otherwise return an exit code of zero.

This change was useful in order to detect when games are crashing.

I also added a simple makefile to make things a little easier to build.